### PR TITLE
On Unix, enable PIC (PIE alternative), fix makefile clean target.

### DIFF
--- a/doc/build-unix.txt
+++ b/doc/build-unix.txt
@@ -128,11 +128,14 @@ exploit even if a vulnerability is found, you can take the following measures:
     The stack and heap are randomly located by default but this allows the code section to be
     randomly located as well.
 
-    On an Amd64 processor where a library was not compiled with -fPIC, this will cause an error
-    such as: "relocation R_X86_64_32 against `......' can not be used when making a shared object;"
-
     To build with PIE, use:
     make -f makefile.unix ... -e PIE=1
+
+    On an Amd64 processor where a library was not compiled with -fPIC, this will cause an error
+    such as: "relocation R_X86_64_32 against `......' can not be used when making a shared object;".
+    
+    Build with PIC instead:
+    make -f makefile.unix ... -e PIC=1
 
     To test that you have built PIE executable, install scanelf, part of paxutils, and use:
     scanelf -e ./evergreencoin
@@ -140,6 +143,13 @@ exploit even if a vulnerability is found, you can take the following measures:
     The output should contain:
      TYPE
     ET_DYN
+
+    On Debian 8:
+    sudo apt-get install hardening-includes
+    hardening-check ./evergreencoind
+
+    Output should contain:
+    Position Independent Executable: yes
 
 * Non-executable Stack
     If the stack is executable then trivial stack based buffer overflow exploits are possible if
@@ -156,3 +166,7 @@ exploit even if a vulnerability is found, you can take the following measures:
     RW- R-- RW-
 
     The STK RW- means that the stack is readable and writeable but not executable.
+
+    For Debian 8, use hardening-check (see above). Output should contain:
+    Stack protected: yes
+

--- a/src/leveldb/Makefile
+++ b/src/leveldb/Makefile
@@ -6,7 +6,7 @@
 # Uncomment exactly one of the lines labelled (A), (B), and (C) below
 # to switch between compilation modes.
 
-OPT ?= -O2 -DNDEBUG       # (A) Production use (optimized mode)
+OPT ?= -O2 -DNDEBUG $(EXTRA_CXXFLAGS)      # (A) Production use (optimized mode)
 # OPT ?= -g2              # (B) Debug mode, w/ full line-level debugging symbols
 # OPT ?= -O2 -g2 -DNDEBUG # (C) Profiling mode: opt, but w/debugging symbols
 #-----------------------------------------------

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -77,11 +77,14 @@ endif
     # Build position independent code to take advantage of Address Space Layout Randomization
     # offered by some kernels.
     # see doc/build-unix.txt for more information.
-	ifdef PIE
+	ifdef PIC
+		LEVELDB_FLAG=-fPIC
+		HARDENING+=-fPIC
+		LDHARDENING+=-pie
+	else ifdef PIE
 		HARDENING+=-fPIE
 		LDHARDENING+=-pie
 	endif
-
     # -D_FORTIFY_SOURCE=2 does some checking for potentially exploitable code patterns in
     # the source such overflowing a statically defined buffer.
 	HARDENING+=-D_FORTIFY_SOURCE=2
@@ -163,7 +166,7 @@ DEFS += $(addprefix -I,$(CURDIR)/leveldb/include)
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 OBJS += obj/txdb-leveldb.o
 leveldb/libleveldb.a:
-	@echo "Building LevelDB ..."; cd leveldb; make libleveldb.a libmemenv.a; cd ..;
+	@echo "Building LevelDB ..."; cd leveldb; EXTRA_CXXFLAGS="$(LEVELDB_FLAG)" make libleveldb.a libmemenv.a; cd ..;
 obj/txdb-leveldb.o: leveldb/libleveldb.a
 
 # auto-generated dependencies:
@@ -217,6 +220,11 @@ clean:
 	-rm -f obj-test/*.P
 	-rm -f obj/build.h
 	-rm -f leveldb/libleveldb.a
-	-rm -f leveldb/libmemenv.a
+	-rm -f leveldb/wlibmemenv.a
+	-rm -f leveldb/db/*.o
+	-rm -f leveldb/table/*.o
+	-rm -f leveldb/util/*.o
+	-rm -f leveldb/port/*.o
+	-rm -f leveldb/helpers/memenv/*.o
 
 FORCE:


### PR DESCRIPTION
PIC sets flag fPIC required for PIE-compatible shared libs
http://linux.die.net/man/1/g++
See doc/build-unix.txt for why this is necessary

Also updates to doc re Debian PIE/stack check
http://unix.stackexchange.com/a/89214

makefile.unix clean now removes leveldb objects