### PR TITLE
Adds LEVELDB_FLAG when compiling a hardened Binary with PIE enabled

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -82,6 +82,7 @@ endif
 		HARDENING+=-fPIC
 		LDHARDENING+=-pie
 	else ifdef PIE
+		LEVELDB_FLAG=-fPIE
 		HARDENING+=-fPIE
 		LDHARDENING+=-pie
 	endif


### PR DESCRIPTION
This sets the -fPIE flag for building libleveldb.a and libmemenv.a. Without this builds on CentOS, Fedora, and Ubuntu 16.04 fail at the final linking stage when built using the PIE=1 flag to generate a hardened binary.